### PR TITLE
Fix instrument view in docs

### DIFF
--- a/docs/examples/workflow.ipynb
+++ b/docs/examples/workflow.ipynb
@@ -107,19 +107,19 @@
     "All pixel positions are relative to the sample position,\n",
     "therefore the sample is at (0, 0, 0).\n",
     "\n",
-    "You can plot the instrument view like below.\n",
-    "\n",
-    "```python\n",
+    "The instrument view is shown using"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import scippneutron as scn\n",
     "\n",
-    "unnecessary_coords = list(coord for coord in da.coords if coord != 'position')\n",
-    "instrument_view_da = da.drop_coords(unnecessary_coords).flatten(['panel', 'id'], 'id').hist()\n",
-    "view = scn.instrument_view(instrument_view_da)\n",
-    "view.children[0].toolbar.cameraz()\n",
-    "view\n",
-    "```\n",
-    "\n",
-    "**It might be very slow or not work in the ``VS Code`` jupyter notebook editor.**"
+    "# Plot one out of 100 pixels to reduce size of docs output\n",
+    "scn.instrument_view(da['id', ::100].hist(), pixel_size=0.0075)"
    ]
   }
  ],
@@ -138,8 +138,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Do not show all pixels to reduce docs output size and fix error with line being too long.

Note that the data is just noise on the panels. Is that intentional?