### PR TITLE
Rename mcstas loader

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -25,7 +25,7 @@
    :recursive:
 
    small_mcstas_sample
-   load_mcstas_nexus
+   load_mcstas2_nexus
 
 ```
 

--- a/docs/examples/workflow.ipynb
+++ b/docs/examples/workflow.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "# Collect parameters and providers\n",
     "import scipp as sc\n",
-    "from ess.nmx.mcstas_loader import load_mcstas_nexus\n",
+    "from ess.nmx.mcstas_loader import load_mcstas2_nexus\n",
     "from ess.nmx.mcstas_loader import (\n",
     "    InputFilepath,\n",
     "    MaximumProbability,\n",
@@ -35,7 +35,7 @@
     "from ess.nmx.data import small_mcstas_sample\n",
     "from ess.nmx.reduction import bin_time_of_arrival, TimeBinSteps\n",
     "\n",
-    "providers = (load_mcstas_nexus, bin_time_of_arrival, )\n",
+    "providers = (load_mcstas2_nexus, bin_time_of_arrival, )\n",
     "\n",
     "file_path = small_mcstas_sample()  # Replace it with your data file path\n",
     "params = {\n",

--- a/src/ess/nmx/__init__.py
+++ b/src/ess/nmx/__init__.py
@@ -12,14 +12,14 @@ except importlib.metadata.PackageNotFoundError:
 del importlib
 
 from .data import small_mcstas_sample
-from .mcstas_loader import InputFilepath, NMXData, load_mcstas_nexus
+from .mcstas_loader import InputFilepath, NMXData, load_mcstas2_nexus
 from .reduction import NMXReducedData, TimeBinSteps
 
 __all__ = [
     "small_mcstas_sample",
     "NMXData",
     "InputFilepath",
-    "load_mcstas_nexus",
+    "load_mcstas2_nexus",
     "NMXReducedData",
     "TimeBinSteps",
 ]

--- a/src/ess/nmx/mcstas_loader.py
+++ b/src/ess/nmx/mcstas_loader.py
@@ -147,13 +147,13 @@ def proton_charge_from_event_data(event_da: sc.DataArray) -> ProtonCharge:
     return ProtonCharge(_proton_charge_scale_factor * event_da.bins.size().sum().data)
 
 
-def load_mcstas_nexus(
+def load_mcstas2_nexus(
     file_path: InputFilepath,
     event_weights_converter: McStasEventWeightsConverter,
     proton_charge_converter: McStasProtonChargeConverter,
     max_probability: Optional[MaximumProbability] = None,
 ) -> NMXData:
-    """Load McStas simulation result from h5(nexus) file.
+    """Load McStas V2 simulation result from h5(nexus) file.
 
     See :func:`~event_weights_from_probability` and
     :func:`~proton_charge_from_weights` for details.

--- a/tests/loader_test.py
+++ b/tests/loader_test.py
@@ -33,7 +33,7 @@ def test_file_reader_mcstas() -> None:
         DefaultMaximumProbability,
         InputFilepath,
         event_weights_from_probability,
-        load_mcstas_nexus,
+        load_mcstas2_nexus,
         proton_charge_from_event_data,
     )
 
@@ -43,7 +43,7 @@ def test_file_reader_mcstas() -> None:
         raw_data = file[entry_path]["events"][()]
         data_length = raw_data.sizes['dim_0']
 
-    dg = load_mcstas_nexus(
+    dg = load_mcstas2_nexus(
         file_path=file_path,
         event_weights_converter=event_weights_from_probability,
         proton_charge_converter=proton_charge_from_event_data,
@@ -92,7 +92,7 @@ def test_file_reader_mcstas_additional_fields(tmp_mcstas_file: pathlib.Path) -> 
     from ess.nmx.mcstas_loader import (
         InputFilepath,
         event_weights_from_probability,
-        load_mcstas_nexus,
+        load_mcstas2_nexus,
         proton_charge_from_event_data,
     )
 
@@ -104,7 +104,7 @@ def test_file_reader_mcstas_additional_fields(tmp_mcstas_file: pathlib.Path) -> 
         del file[entry_path]
         file[new_entry_path] = dataset
 
-    dg = load_mcstas_nexus(
+    dg = load_mcstas2_nexus(
         file_path=InputFilepath(str(tmp_mcstas_file)),
         event_weights_converter=event_weights_from_probability,
         proton_charge_converter=proton_charge_from_event_data,

--- a/tests/workflow_test.py
+++ b/tests/workflow_test.py
@@ -15,13 +15,13 @@ def mcstas_workflow() -> sl.Pipeline:
         McStasEventWeightsConverter,
         McStasProtonChargeConverter,
         event_weights_from_probability,
-        load_mcstas_nexus,
+        load_mcstas2_nexus,
         proton_charge_from_event_data,
     )
     from ess.nmx.reduction import TimeBinSteps, bin_time_of_arrival
 
     return sl.Pipeline(
-        [load_mcstas_nexus, bin_time_of_arrival],
+        providers=(load_mcstas2_nexus, bin_time_of_arrival),
         params={
             InputFilepath: small_mcstas_sample(),
             MaximumProbability: DefaultMaximumProbability,


### PR DESCRIPTION
Updating McStas version from 2 to 3 will break the loader.
Therefore IDS(Justin) agreed with specifying the version of the McStas that current loader is expecting
in the documentation and the function name.
Justin said it will be much later that NMX is going to use McStas 3,
so we are not expecting any urgent request of McStas version 3 loader right now.

If general McStas loader is implemented as mentioned here: https://github.com/scipp/scippneutron/issues/458 
we might not have to implement them separately in nmx package.