### PR TITLE
Fix nightly requirements.

### DIFF
--- a/requirements/nightly.in
+++ b/requirements/nightly.in
@@ -7,7 +7,7 @@ pooch
 pandas
 gemmi
 defusedxml
-https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 sciline @ git+https://github.com/scipp/sciline@main
 scippnexus @ git+https://github.com/scipp/scippnexus@main
 plopp @ git+https://github.com/scipp/plopp@main

--- a/requirements/nightly.txt
+++ b/requirements/nightly.txt
@@ -79,7 +79,7 @@ requests==2.31.0
     # via pooch
 sciline @ git+https://github.com/scipp/sciline@main
     # via -r nightly.in
-scipp @ https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+scipp @ https://github.com/scipp/scipp/releases/download/nightly/scipp-nightly-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
     # via
     #   -r nightly.in
     #   scippnexus


### PR DESCRIPTION
Scipp dependency went to py39 by accident and broke the nightly... 