### PR TITLE
Use constants consistently

### DIFF
--- a/src/ess/nmx/mcstas_xml.py
+++ b/src/ess/nmx/mcstas_xml.py
@@ -7,7 +7,7 @@ from typing import Iterable, Optional, Protocol, Tuple, TypeVar
 
 import scipp as sc
 
-from .const import DETECTOR_DIM
+from .const import DETECTOR_DIM, PIXEL_DIM
 from .types import FilePath
 
 T = TypeVar('T')
@@ -314,8 +314,8 @@ def _construct_pixel_ids(detector_descs: Tuple[DetectorDesc, ...]) -> sc.Variabl
     intervals = [
         (desc.id_start, desc.id_start + desc.total_pixels) for desc in detector_descs
     ]
-    ids = [sc.arange('id', start, stop, unit=None) for start, stop in intervals]
-    return sc.concat(ids, 'id')
+    ids = [sc.arange(PIXEL_DIM, start, stop, unit=None) for start, stop in intervals]
+    return sc.concat(ids, PIXEL_DIM)
 
 
 def _pixel_positions(
@@ -325,7 +325,7 @@ def _pixel_positions(
 
     Position of each pixel is relative to the position_offset.
     """
-    pixel_idx = sc.arange('id', detector.total_pixels)
+    pixel_idx = sc.arange(PIXEL_DIM, detector.total_pixels)
     n_col = sc.scalar(detector.num_fast_pixels_per_row)
 
     pixel_n_slow = pixel_idx // n_col

--- a/src/ess/nmx/reduction.py
+++ b/src/ess/nmx/reduction.py
@@ -8,7 +8,7 @@ import h5py
 import sciline
 import scipp as sc
 
-from .const import DETECTOR_DIM
+from .const import DETECTOR_DIM, PIXEL_DIM, TOF_DIM
 from .mcstas_xml import McStasInstrument
 from .types import DetectorIndex, DetectorName, TimeBinSteps
 
@@ -155,7 +155,7 @@ class NMXReducedData(_SharedFields, sc.DataGroup):
         # Time of arrival bin edges
         self._create_dataset_from_var(
             root_entry=nx_detector_1,
-            var=self.counts.coords['t'],
+            var=self.counts.coords[TOF_DIM],
             name="t_bin",
             long_name="t_bin TOF (ms)",
         )
@@ -163,7 +163,7 @@ class NMXReducedData(_SharedFields, sc.DataGroup):
         self._create_compressed_dataset(
             root_entry=nx_detector_1,
             name="pixel_id",
-            var=self.counts.coords['id'],
+            var=self.counts.coords[PIXEL_DIM],
             long_name="pixel ID",
         )
         return nx_instrument

--- a/tests/loader_test.py
+++ b/tests/loader_test.py
@@ -11,7 +11,7 @@ import scippnexus as snx
 from scipp.testing import assert_allclose, assert_identical
 
 from ess.nmx import default_parameters
-from ess.nmx.const import DETECTOR_DIM
+from ess.nmx.const import DETECTOR_DIM, DETECTOR_SHAPE
 from ess.nmx.data import small_mcstas_2_sample, small_mcstas_3_sample
 from ess.nmx.mcstas_loader import bank_names_to_detector_names
 from ess.nmx.mcstas_loader import providers as loader_providers
@@ -51,7 +51,7 @@ def check_scalar_properties_mcstas_2(dg: NMXData):
 
 def check_nmxdata_properties(dg: NMXData, fast_axis, slow_axis) -> None:
     assert isinstance(dg, sc.DataGroup)
-    assert dg.shape == (1280 * 1280, 1)
+    assert dg.shape == (DETECTOR_SHAPE[0] * DETECTOR_SHAPE[1], 1)
     # Check maximum value of weights.
     assert_allclose(
         dg.weights.max().data,

--- a/tests/workflow_test.py
+++ b/tests/workflow_test.py
@@ -5,6 +5,7 @@ import sciline as sl
 import scipp as sc
 
 from ess.nmx import default_parameters
+from ess.nmx.const import DETECTOR_SHAPE, PIXEL_DIM, TOF_DIM
 from ess.nmx.data import small_mcstas_2_sample, small_mcstas_3_sample
 from ess.nmx.mcstas_loader import providers as load_providers
 from ess.nmx.reduction import bin_time_of_arrival
@@ -47,7 +48,7 @@ def test_pipeline_mcstas_loader(mcstas_workflow: sl.Pipeline) -> None:
     mcstas_workflow[DetectorIndex] = 0
     nmx_data = mcstas_workflow.compute(NMXData)
     assert isinstance(nmx_data, sc.DataGroup)
-    assert nmx_data.sizes['id'] == 1280 * 1280
+    assert nmx_data.sizes[PIXEL_DIM] == DETECTOR_SHAPE[0] * DETECTOR_SHAPE[1]
 
 
 def test_pipeline_mcstas_reduction(mcstas_workflow: sl.Pipeline) -> None:
@@ -56,4 +57,4 @@ def test_pipeline_mcstas_reduction(mcstas_workflow: sl.Pipeline) -> None:
 
     nmx_reduced_data = mcstas_workflow.compute(NMXReducedData)
     assert isinstance(nmx_reduced_data, sc.DataGroup)
-    assert nmx_reduced_data.sizes['t'] == 50
+    assert nmx_reduced_data.sizes[TOF_DIM] == 50


### PR DESCRIPTION
I forgot to use the dimension name constants in some places.
Not sure they're actually good or if it's better to use the names directly.
In any case, it's best to be consistent one way or the other.
I left the names in `tests/exporter_test.py` since that tests for what is actually exported and we don't want that to change without the test breaking.