### PR TITLE
refactor: add mcstas workflow, remove custom datastructures

### DIFF
--- a/docs/examples/workflow.ipynb
+++ b/docs/examples/workflow.ipynb
@@ -21,27 +21,28 @@
    "source": [
     "import sciline as sl\n",
     "\n",
-    "from ess.nmx.mcstas_loader import providers as loader_providers\n",
-    "from ess.nmx.mcstas_xml import read_mcstas_geometry_xml\n",
+    "from ess.nmx.mcstas import McStasWorkflow\n",
     "from ess.nmx.data import small_mcstas_3_sample, small_mcstas_2_sample\n",
-    "from ess.nmx.types import *\n",
-    "from ess.nmx.reduction import NMXData, NMXReducedData, bin_time_of_arrival\n",
     "\n",
-    "pl = sl.Pipeline((*loader_providers, read_mcstas_geometry_xml, bin_time_of_arrival))\n",
+    "from ess.nmx.types import *\n",
+    "from ess.nmx.reduction import NMXData, NMXReducedData\n",
+    "from ess.nmx.nexus import export_as_nexus\n",
+    "\n",
+    "wf = McStasWorkflow()\n",
     "# Replace with the path to your own file\n",
-    "pl[FilePath] = small_mcstas_3_sample()\n",
-    "pl[MaximumProbability] = 10000\n",
-    "pl[TimeBinSteps] = 50\n",
+    "wf[FilePath] = small_mcstas_3_sample()\n",
+    "wf[MaximumProbability] = 10000\n",
+    "wf[TimeBinSteps] = 50\n",
     "# DetectorIndex selects what detector panels to include in the run\n",
     "# in this case we select all three panels.\n",
-    "pl.set_param_series(DetectorIndex, range(3))"
+    "wf.set_param_series(DetectorIndex, range(3))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To see what the pipeline can produce, display it:"
+    "To see what the workflow can produce, display it:"
    ]
   },
   {
@@ -50,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pl"
+    "wf"
    ]
   },
   {
@@ -66,8 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nmx_workflow = pl.get(NMXReducedData)\n",
-    "nmx_workflow.visualize()"
+    "wf.visualize(NMXReducedData)"
    ]
   },
   {
@@ -84,7 +84,7 @@
    "outputs": [],
    "source": [
     "# Event data grouped by pixel id for each of the selected detectors\n",
-    "dg = nmx_workflow.compute(sl.Series[DetectorIndex, NMXData])\n",
+    "dg = wf.compute(sl.Series[DetectorIndex, NMXData])\n",
     "dg"
    ]
   },
@@ -95,7 +95,7 @@
    "outputs": [],
    "source": [
     "# Data from all selected detectors binned by panel, pixel and timeslice\n",
-    "binned_dg = nmx_workflow.compute(NMXReducedData)\n",
+    "binned_dg = wf.compute(NMXReducedData)\n",
     "binned_dg"
    ]
   },
@@ -116,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#binned_dg.export_as_nexus('test.nxs')"
+    "export_as_nexus(binned_dg, 'test.nxs')"
    ]
   },
   {

--- a/src/ess/nmx/mcstas/__init__.py
+++ b/src/ess/nmx/mcstas/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+
+# flake8: noqa
+import importlib.metadata
+
+try:
+    __version__ = importlib.metadata.version(__package__ or __name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"
+
+del importlib
+
+
+def McStasWorkflow():
+    import sciline as sl
+
+    from ess.nmx.reduction import bin_time_of_arrival
+
+    from .load import providers as loader_providers
+    from .xml import read_mcstas_geometry_xml
+
+    return sl.Pipeline(
+        (*loader_providers, read_mcstas_geometry_xml, bin_time_of_arrival)
+    )

--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -6,9 +6,8 @@ from typing import Dict, List
 import scipp as sc
 import scippnexus as snx
 
-from .mcstas_xml import McStasInstrument, read_mcstas_geometry_xml
-from .reduction import NMXData
-from .types import (
+from ..reduction import NMXData
+from ..types import (
     CrystalRotation,
     DetectorBankPrefix,
     DetectorIndex,
@@ -19,6 +18,7 @@ from .types import (
     ProtonCharge,
     RawEventData,
 )
+from .xml import McStasInstrument, read_mcstas_geometry_xml
 
 
 def detector_name_from_index(index: DetectorIndex) -> DetectorName:
@@ -154,10 +154,14 @@ def load_mcstas(
     coords = instrument.to_coords(detector_name)
     coords.pop('pixel_id')
     return NMXData(
-        weights=da,
-        proton_charge=proton_charge,
-        crystal_rotation=crystal_rotation,
-        **coords,
+        sc.DataGroup(
+            dict(
+                weights=da,
+                proton_charge=proton_charge,
+                crystal_rotation=crystal_rotation,
+                **coords,
+            )
+        )
     )
 
 

--- a/src/ess/nmx/nexus.py
+++ b/src/ess/nmx/nexus.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import io
+import pathlib
+from functools import partial
+from typing import Optional, Union
+
+import h5py
+import scipp as sc
+
+
+def _create_dataset_from_var(
+    *,
+    root_entry: h5py.Group,
+    var: sc.Variable,
+    name: str,
+    long_name: Optional[str] = None,
+    compression: Optional[str] = None,
+    compression_opts: Optional[int] = None,
+) -> h5py.Dataset:
+    compression_options = dict()
+    if compression is not None:
+        compression_options["compression"] = compression
+    if compression_opts is not None:
+        compression_options["compression_opts"] = compression_opts
+
+    dataset = root_entry.create_dataset(
+        name,
+        data=var.values,
+        **compression_options,
+    )
+    dataset.attrs["units"] = str(var.unit)
+    if long_name is not None:
+        dataset.attrs["long_name"] = long_name
+    return dataset
+
+
+_create_compressed_dataset = partial(
+    _create_dataset_from_var,
+    compression="gzip",
+    compression_opts=4,
+)
+
+
+def _create_root_data_entry(file_obj: h5py.File) -> h5py.Group:
+    nx_entry = file_obj.create_group("NMX_data")
+    nx_entry.attrs["NX_class"] = "NXentry"
+    nx_entry.attrs["default"] = "data"
+    nx_entry.attrs["name"] = "NMX"
+    nx_entry["name"] = "NMX"
+    nx_entry["definition"] = "TOFRAW"
+    return nx_entry
+
+
+def _create_sample_group(data: sc.DataGroup, nx_entry: h5py.Group) -> h5py.Group:
+    nx_sample = nx_entry.create_group("NXsample")
+    nx_sample["name"] = data['sample_name'].value
+    _create_dataset_from_var(
+        root_entry=nx_sample,
+        var=data['crystal_rotation'],
+        name='crystal_rotation',
+        long_name='crystal rotation in Phi (XYZ)',
+    )
+    return nx_sample
+
+
+def _create_instrument_group(data: sc.DataGroup, nx_entry: h5py.Group) -> h5py.Group:
+    nx_instrument = nx_entry.create_group("NXinstrument")
+    nx_instrument.create_dataset("proton_charge", data=data['proton_charge'].values)
+
+    nx_detector_1 = nx_instrument.create_group("detector_1")
+    # Detector counts
+    _create_compressed_dataset(
+        root_entry=nx_detector_1,
+        name="counts",
+        var=data['counts'],
+    )
+    # Time of arrival bin edges
+    _create_dataset_from_var(
+        root_entry=nx_detector_1,
+        var=data['counts'].coords['t'],
+        name="t_bin",
+        long_name="t_bin TOF (ms)",
+    )
+    # Pixel IDs
+    _create_compressed_dataset(
+        root_entry=nx_detector_1,
+        name="pixel_id",
+        var=data['counts'].coords['id'],
+        long_name="pixel ID",
+    )
+    return nx_instrument
+
+
+def _create_detector_group(data: sc.DataGroup, nx_entry: h5py.Group) -> h5py.Group:
+    nx_detector = nx_entry.create_group("NXdetector")
+    # Position of the first pixel (lowest ID) in the detector
+    _create_compressed_dataset(
+        root_entry=nx_detector,
+        name="origin",
+        var=data['origin_position'],
+    )
+    # Fast axis, along where the pixel ID increases by 1
+    _create_dataset_from_var(
+        root_entry=nx_detector, var=data['fast_axis'], name="fast_axis"
+    )
+    # Slow axis, along where the pixel ID increases
+    # by the number of pixels in the fast axis
+    _create_dataset_from_var(
+        root_entry=nx_detector, var=data['slow_axis'], name="slow_axis"
+    )
+    return nx_detector
+
+
+def _create_source_group(data: sc.DataGroup, nx_entry: h5py.Group) -> h5py.Group:
+    nx_source = nx_entry.create_group("NXsource")
+    nx_source["name"] = "European Spallation Source"
+    nx_source["short_name"] = "ESS"
+    nx_source["type"] = "Spallation Neutron Source"
+    nx_source["distance"] = sc.norm(data['source_position']).value
+    nx_source["probe"] = "neutron"
+    nx_source["target_material"] = "W"
+    return nx_source
+
+
+def export_as_nexus(
+    data: sc.DataGroup, output_file: Union[str, pathlib.Path, io.BytesIO]
+) -> None:
+    """Export the reduced data to a NeXus file.
+
+    Currently exporting step is not expected to be part of sciline pipelines.
+    """
+    with h5py.File(output_file, "w") as f:
+        f.attrs["default"] = "NMX_data"
+        nx_entry = _create_root_data_entry(f)
+        _create_sample_group(data, nx_entry)
+        _create_instrument_group(data, nx_entry)
+        _create_detector_group(data, nx_entry)
+        _create_source_group(data, nx_entry)

--- a/src/ess/nmx/reduction.py
+++ b/src/ess/nmx/reduction.py
@@ -1,227 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-import io
-import pathlib
-from typing import Optional, Union
+from typing import NewType
 
-import h5py
 import sciline
 import scipp as sc
 
-from .mcstas_xml import McStasInstrument
+from .mcstas.xml import McStasInstrument
 from .types import DetectorIndex, DetectorName, TimeBinSteps
 
-
-class _SharedFields(sc.DataGroup):
-    """All shared fields between NMXData and NMXReducedData.
-
-    ``weights`` is only present in NMXData due to potential memory issues.
-    """
-
-    @property
-    def origin_position(self) -> sc.Variable:
-        """Position of the first pixel (lowest ID) in the detector.
-
-        Relative position from the sample."""
-        return self['origin_position']
-
-    @property
-    def crystal_rotation(self) -> sc.Variable:
-        """Rotation of the crystal."""
-
-        return self['crystal_rotation']
-
-    @property
-    def sample_name(self) -> sc.Variable:
-        return self['sample_name']
-
-    @property
-    def fast_axis(self) -> sc.Variable:
-        """Fast axis, along where the pixel ID increases by 1."""
-        return self['fast_axis']
-
-    @property
-    def slow_axis(self) -> sc.Variable:
-        """Slow axis, along where the pixel ID increases by > 1.
-
-        The pixel ID increases by the number of pixels in the fast axis."""
-        return self['slow_axis']
-
-    @property
-    def proton_charge(self) -> sc.Variable:
-        """Accumulated number of protons during the measurement."""
-        return self['proton_charge']
-
-    @property
-    def source_position(self) -> sc.Variable:
-        """Relative position of the source from the sample."""
-        return self['source_position']
-
-    @property
-    def sample_position(self) -> sc.Variable:
-        """Relative position of the sample from the sample. (0, 0, 0)"""
-        return self['sample_position']
-
-
-class NMXData(_SharedFields, sc.DataGroup):
-    @property
-    def weights(self) -> sc.DataArray:
-        """Event data grouped by pixel id."""
-        return self['weights']
-
-
-class NMXReducedData(_SharedFields, sc.DataGroup):
-    @property
-    def counts(self) -> sc.DataArray:
-        """Binned time of arrival data from flattened event data."""
-        return self['counts']
-
-    def _create_dataset_from_var(
-        self,
-        *,
-        root_entry: h5py.Group,
-        var: sc.Variable,
-        name: str,
-        long_name: Optional[str] = None,
-        compression: Optional[str] = None,
-        compression_opts: Optional[int] = None,
-    ) -> h5py.Dataset:
-        compression_options = dict()
-        if compression is not None:
-            compression_options["compression"] = compression
-        if compression_opts is not None:
-            compression_options["compression_opts"] = compression_opts
-
-        dataset = root_entry.create_dataset(
-            name,
-            data=var.values,
-            **compression_options,
-        )
-        dataset.attrs["units"] = str(var.unit)
-        if long_name is not None:
-            dataset.attrs["long_name"] = long_name
-        return dataset
-
-    def _create_compressed_dataset(
-        self,
-        *,
-        root_entry: h5py.Group,
-        name: str,
-        var: sc.Variable,
-        long_name: Optional[str] = None,
-    ) -> h5py.Dataset:
-        return self._create_dataset_from_var(
-            root_entry=root_entry,
-            var=var,
-            name=name,
-            long_name=long_name,
-            compression="gzip",
-            compression_opts=4,
-        )
-
-    def _create_root_data_entry(self, file_obj: h5py.File) -> h5py.Group:
-        nx_entry = file_obj.create_group("NMX_data")
-        nx_entry.attrs["NX_class"] = "NXentry"
-        nx_entry.attrs["default"] = "data"
-        nx_entry.attrs["name"] = "NMX"
-        nx_entry["name"] = "NMX"
-        nx_entry["definition"] = "TOFRAW"
-        return nx_entry
-
-    def _create_sample_group(self, nx_entry: h5py.Group) -> h5py.Group:
-        nx_sample = nx_entry.create_group("NXsample")
-        nx_sample["name"] = self.sample_name.value
-        # Crystal rotation
-        self._create_dataset_from_var(
-            root_entry=nx_sample,
-            var=self.crystal_rotation,
-            name='crystal_rotation',
-            long_name='crystal rotation in Phi (XYZ)',
-        )
-        return nx_sample
-
-    def _create_instrument_group(self, nx_entry: h5py.Group) -> h5py.Group:
-        nx_instrument = nx_entry.create_group("NXinstrument")
-        nx_instrument.create_dataset("proton_charge", data=self.proton_charge.values)
-
-        nx_detector_1 = nx_instrument.create_group("detector_1")
-        # Detector counts
-        self._create_compressed_dataset(
-            root_entry=nx_detector_1,
-            name="counts",
-            var=self.counts,
-        )
-        # Time of arrival bin edges
-        self._create_dataset_from_var(
-            root_entry=nx_detector_1,
-            var=self.counts.coords['t'],
-            name="t_bin",
-            long_name="t_bin TOF (ms)",
-        )
-        # Pixel IDs
-        self._create_compressed_dataset(
-            root_entry=nx_detector_1,
-            name="pixel_id",
-            var=self.counts.coords['id'],
-            long_name="pixel ID",
-        )
-        return nx_instrument
-
-    def _create_detector_group(self, nx_entry: h5py.Group) -> h5py.Group:
-        nx_detector = nx_entry.create_group("NXdetector")
-        # Position of the first pixel (lowest ID) in the detector
-        self._create_compressed_dataset(
-            root_entry=nx_detector,
-            name="origin",
-            var=self.origin_position,
-        )
-        # Fast axis, along where the pixel ID increases by 1
-        self._create_dataset_from_var(
-            root_entry=nx_detector, var=self.fast_axis, name="fast_axis"
-        )
-        # Slow axis, along where the pixel ID increases
-        # by the number of pixels in the fast axis
-        self._create_dataset_from_var(
-            root_entry=nx_detector, var=self.slow_axis, name="slow_axis"
-        )
-        return nx_detector
-
-    def _create_source_group(self, nx_entry: h5py.Group) -> h5py.Group:
-        nx_source = nx_entry.create_group("NXsource")
-        nx_source["name"] = "European Spallation Source"
-        nx_source["short_name"] = "ESS"
-        nx_source["type"] = "Spallation Neutron Source"
-        nx_source["distance"] = sc.norm(self.source_position).value
-        nx_source["probe"] = "neutron"
-        nx_source["target_material"] = "W"
-        return nx_source
-
-    def export_as_nexus(
-        self, output_file_base: Union[str, pathlib.Path, io.BytesIO]
-    ) -> None:
-        """Export the reduced data to a NeXus file.
-
-        Currently exporting step is not expected to be part of sciline pipelines.
-        """
-        if isinstance(output_file_base, (str, pathlib.Path)):
-            file_base = pathlib.Path(output_file_base)
-            if file_base.suffix not in (".h5", ".nxs"):
-                raise ValueError("Output file name must end with .h5 or .nxs")
-        else:
-            file_base = output_file_base
-
-        with h5py.File(file_base, "w") as out_file:
-            out_file.attrs["default"] = "NMX_data"
-            # Root Data Entry
-            nx_entry = self._create_root_data_entry(out_file)
-            # Sample
-            self._create_sample_group(nx_entry)
-            # Instrument
-            self._create_instrument_group(nx_entry)
-            # Detector
-            self._create_detector_group(nx_entry)
-            # Source
-            self._create_source_group(nx_entry)
+NMXData = NewType("NMXData", sc.DataGroup)
+NMXReducedData = NewType("NMXData", sc.DataGroup)
 
 
 def bin_time_of_arrival(
@@ -239,6 +27,10 @@ def bin_time_of_arrival(
     new_coords.pop('pixel_id')
 
     return NMXReducedData(
-        counts=counts,
-        **{**nmx_data, **new_coords},
+        sc.DataGroup(
+            dict(
+                counts=counts,
+                **{**nmx_data, **new_coords},
+            )
+        )
     )

--- a/tests/exporter_test.py
+++ b/tests/exporter_test.py
@@ -2,16 +2,16 @@
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 import io
 
+import numpy as np
 import pytest
+import scipp as sc
 
+from ess.nmx.nexus import export_as_nexus
 from ess.nmx.reduction import NMXReducedData
 
 
 @pytest.fixture
 def reduced_data() -> NMXReducedData:
-    import numpy as np
-    import scipp as sc
-
     rng = np.random.default_rng(42)
     id_list = sc.array(dims=['event'], values=rng.integers(0, 12, size=100))
     t_list = sc.array(dims=['event'], values=rng.random(size=100, dtype=float))
@@ -25,28 +25,32 @@ def reduced_data() -> NMXReducedData:
     )
 
     return NMXReducedData(
-        counts=counts,
-        proton_charge=sc.scalar(1.0, unit='counts'),
-        crystal_rotation=sc.vector(value=[0.0, 20.0, 0.0], unit='deg'),
-        fast_axis=sc.vectors(
-            dims=['panel'],
-            values=[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
-            unit='m',
-        ),
-        slow_axis=sc.vectors(
-            dims=['panel'],
-            values=[[0.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
-            unit='m',
-        ),
-        origin_position=sc.vectors(
-            dims=['panel'],
-            values=[[-0.2, 0.0, 0.0], [0.0, 0.0, 0.0], [0.2, 0.0, 0.0]],
-            unit='m',
-        ),
-        sample_position=sc.vector(value=[0.0, 0.0, 0.0], unit='m'),
-        source_position=sc.vector(value=[-3, 0.0, -4], unit='m'),
-        sample_name=sc.scalar('Unit Test Sample'),
-        position=sc.zeros(dims=['panel', 'id'], shape=[3, 4], unit='m'),
+        sc.DataGroup(
+            dict(
+                counts=counts,
+                proton_charge=sc.scalar(1.0, unit='counts'),
+                crystal_rotation=sc.vector(value=[0.0, 20.0, 0.0], unit='deg'),
+                fast_axis=sc.vectors(
+                    dims=['panel'],
+                    values=[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+                    unit='m',
+                ),
+                slow_axis=sc.vectors(
+                    dims=['panel'],
+                    values=[[0.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+                    unit='m',
+                ),
+                origin_position=sc.vectors(
+                    dims=['panel'],
+                    values=[[-0.2, 0.0, 0.0], [0.0, 0.0, 0.0], [0.2, 0.0, 0.0]],
+                    unit='m',
+                ),
+                sample_position=sc.vector(value=[0.0, 0.0, 0.0], unit='m'),
+                source_position=sc.vector(value=[-3, 0.0, -4], unit='m'),
+                sample_name=sc.scalar('Unit Test Sample'),
+                position=sc.zeros(dims=['panel', 'id'], shape=[3, 4], unit='m'),
+            )
+        )
     )
 
 
@@ -66,7 +70,7 @@ def test_mcstas_reduction_export_to_bytestream(reduced_data: NMXReducedData) -> 
     ]
 
     with io.BytesIO() as bio:
-        reduced_data.export_as_nexus(bio)
+        export_as_nexus(reduced_data, bio)
         with h5py.File(bio, 'r') as f:
             assert 'NMX_data' in f
             nmx_data: h5py.Group = f.require_group('NMX_data')
@@ -74,39 +78,37 @@ def test_mcstas_reduction_export_to_bytestream(reduced_data: NMXReducedData) -> 
                 assert field in nmx_data
 
             nx_detector = nmx_data.require_group('NXdetector')
-            assert np.all(nx_detector['fast_axis'][()] == reduced_data.fast_axis.values)
-            assert np.all(nx_detector['slow_axis'][()] == reduced_data.slow_axis.values)
             assert np.all(
-                nx_detector['origin'][()] == reduced_data.origin_position.values
+                nx_detector['fast_axis'][()] == reduced_data['fast_axis'].values
+            )
+            assert np.all(
+                nx_detector['slow_axis'][()] == reduced_data['slow_axis'].values
+            )
+            assert np.all(
+                nx_detector['origin'][()] == reduced_data['origin_position'].values
             )
 
             instrument_data = nmx_data.require_group('NXinstrument')
             assert (
-                instrument_data['proton_charge'][()] == reduced_data.proton_charge.value
+                instrument_data['proton_charge'][()]
+                == reduced_data['proton_charge'].value
             )
 
             det1_data = instrument_data.require_group('detector_1')
-            assert np.all(det1_data['counts'][()] == reduced_data.counts.values)
+            assert np.all(det1_data['counts'][()] == reduced_data['counts'].values)
             assert np.all(
-                det1_data['pixel_id'][()] == reduced_data.counts.coords['id'].values
+                det1_data['pixel_id'][()] == reduced_data['counts'].coords['id'].values
             )
             assert np.all(
-                det1_data['t_bin'][()] == reduced_data.counts.coords['t'].values
+                det1_data['t_bin'][()] == reduced_data['counts'].coords['t'].values
             )
 
             nx_sample = nmx_data.require_group('NXsample')
             sample_name: bytes = nx_sample['name'][()]
-            assert sample_name.decode() == reduced_data.sample_name.value
+            assert sample_name.decode() == reduced_data['sample_name'].value
 
             nx_source = nmx_data.require_group('NXsource')
             assert (
-                nx_source['distance'][()] == sc.norm(reduced_data.source_position).value
+                nx_source['distance'][()]
+                == sc.norm(reduced_data['source_position']).value
             )
-
-
-def test_mcstas_reduction_export_wrong_extension_raises(
-    reduced_data: NMXReducedData,
-) -> None:
-    """Test export method."""
-    with pytest.raises(ValueError, match="Output file name must end with .h5 or .nxs"):
-        reduced_data.export_as_nexus('wrong_name.txt')

--- a/tests/loader_test.py
+++ b/tests/loader_test.py
@@ -12,8 +12,8 @@ from scipp.testing import assert_allclose, assert_identical
 
 from ess.nmx import default_parameters
 from ess.nmx.data import small_mcstas_2_sample, small_mcstas_3_sample
-from ess.nmx.mcstas_loader import bank_names_to_detector_names
-from ess.nmx.mcstas_loader import providers as loader_providers
+from ess.nmx.mcstas.load import bank_names_to_detector_names
+from ess.nmx.mcstas.load import providers as loader_providers
 from ess.nmx.reduction import NMXData
 from ess.nmx.types import (
     DetectorBankPrefix,
@@ -37,15 +37,15 @@ def check_scalar_properties_mcstas_2(dg: NMXData):
     Expected numbers are hard-coded based on the sample file.
     """
     assert_identical(
-        dg.proton_charge,
+        dg['proton_charge'],
         sc.scalar(1e-4 * dg['weights'].bins.size().sum().data.values, unit=None),
     )
-    assert_identical(dg.crystal_rotation, sc.vector([20, 0, 90], unit='deg'))
-    assert_identical(dg.sample_position, sc.vector(value=[0, 0, 0], unit='m'))
+    assert_identical(dg['crystal_rotation'], sc.vector([20, 0, 90], unit='deg'))
+    assert_identical(dg['sample_position'], sc.vector(value=[0, 0, 0], unit='m'))
     assert_identical(
-        dg.source_position, sc.vector(value=[-0.53123, 0.0, -157.405], unit='m')
+        dg['source_position'], sc.vector(value=[-0.53123, 0.0, -157.405], unit='m')
     )
-    assert dg.sample_name == sc.scalar("sampleMantid")
+    assert dg['sample_name'] == sc.scalar("sampleMantid")
 
 
 def check_nmxdata_properties(dg: NMXData, fast_axis, slow_axis) -> None:
@@ -53,13 +53,15 @@ def check_nmxdata_properties(dg: NMXData, fast_axis, slow_axis) -> None:
     assert dg.shape == ((1280, 1280)[0] * (1280, 1280)[1], 1)
     # Check maximum value of weights.
     assert_allclose(
-        dg.weights.max().data,
+        dg['weights'].max().data,
         sc.scalar(default_parameters[MaximumProbability], unit='counts', dtype=float),
         atol=sc.scalar(1e-10, unit='counts'),
         rtol=sc.scalar(1e-8),
     )
-    assert_allclose(sc.squeeze(dg.fast_axis, 'panel'), fast_axis, atol=sc.scalar(0.005))
-    assert_identical(sc.squeeze(dg.slow_axis, 'panel'), slow_axis)
+    assert_allclose(
+        sc.squeeze(dg['fast_axis'], 'panel'), fast_axis, atol=sc.scalar(0.005)
+    )
+    assert_identical(sc.squeeze(dg['slow_axis'], 'panel'), slow_axis)
 
 
 @pytest.mark.parametrize(
@@ -101,15 +103,15 @@ def check_scalar_properties_mcstas_3(dg: NMXData):
     Expected numbers are hard-coded based on the sample file.
     """
     assert_identical(
-        dg.proton_charge,
+        dg['proton_charge'],
         sc.scalar(1e-4 * dg['weights'].bins.size().sum().data.values, unit=None),
     )
-    assert_identical(dg.crystal_rotation, sc.vector([0, 0, 0], unit='deg'))
-    assert_identical(dg.sample_position, sc.vector(value=[0, 0, 0], unit='m'))
+    assert_identical(dg['crystal_rotation'], sc.vector([0, 0, 0], unit='deg'))
+    assert_identical(dg['sample_position'], sc.vector(value=[0, 0, 0], unit='m'))
     assert_identical(
-        dg.source_position, sc.vector(value=[-0.53123, 0.0, -157.405], unit='m')
+        dg['source_position'], sc.vector(value=[-0.53123, 0.0, -157.405], unit='m')
     )
-    assert dg.sample_name == sc.scalar("sampleMantid")
+    assert dg['sample_name'] == sc.scalar("sampleMantid")
 
 
 @pytest.mark.parametrize(
@@ -141,7 +143,7 @@ def test_file_reader_mcstas3(detector_index, fast_axis, slow_axis) -> None:
         data_length = raw_data.sizes['dim_0']
 
     check_scalar_properties_mcstas_3(dg)
-    assert dg.weights.bins.size().sum().value == data_length
+    assert dg['weights'].bins.size().sum().value == data_length
     check_nmxdata_properties(dg, sc.vector(fast_axis), sc.vector(slow_axis))
 
 

--- a/tests/workflow_test.py
+++ b/tests/workflow_test.py
@@ -6,8 +6,8 @@ import scipp as sc
 
 from ess.nmx import default_parameters
 from ess.nmx.data import small_mcstas_2_sample, small_mcstas_3_sample
-from ess.nmx.mcstas_loader import providers as load_providers
-from ess.nmx.reduction import bin_time_of_arrival
+from ess.nmx.mcstas.load import providers as load_providers
+from ess.nmx.reduction import NMXData, NMXReducedData, bin_time_of_arrival
 from ess.nmx.types import DetectorIndex, FilePath, TimeBinSteps
 
 
@@ -42,8 +42,6 @@ def test_pipeline_builder(mcstas_workflow: sl.Pipeline, mcstas_file_path: str) -
 
 def test_pipeline_mcstas_loader(mcstas_workflow: sl.Pipeline) -> None:
     """Test if the loader graph is complete."""
-    from ess.nmx.mcstas_loader import NMXData
-
     mcstas_workflow[DetectorIndex] = 0
     nmx_data = mcstas_workflow.compute(NMXData)
     assert isinstance(nmx_data, sc.DataGroup)
@@ -52,8 +50,6 @@ def test_pipeline_mcstas_loader(mcstas_workflow: sl.Pipeline) -> None:
 
 def test_pipeline_mcstas_reduction(mcstas_workflow: sl.Pipeline) -> None:
     """Test if the loader graph is complete."""
-    from ess.nmx.reduction import NMXReducedData
-
     nmx_reduced_data = mcstas_workflow.compute(NMXReducedData)
     assert isinstance(nmx_reduced_data, sc.DataGroup)
     assert nmx_reduced_data.sizes['t'] == 50


### PR DESCRIPTION
Fixes #47 

Removes the custom datastructures in `reduce.py` and creates a `McStasWorkflow` in accordance with the guidelines.