### PR TITLE
Rename MaximumProbability to MaximumCounts and add MaximumProbability.

### DIFF
--- a/docs/examples/workflow.ipynb
+++ b/docs/examples/workflow.ipynb
@@ -29,7 +29,7 @@
     "wf = McStasWorkflow()\n",
     "# Replace with the path to your own file\n",
     "wf[FilePath] = small_mcstas_3_sample()\n",
-    "wf[MaximumProbability] = 10000\n",
+    "wf[MaximumCounts] = 10000\n",
     "wf[TimeBinSteps] = 50"
    ]
   },
@@ -172,7 +172,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "nmx-dev-310",
    "language": "python",
    "name": "python3"
   },
@@ -186,7 +186,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/src/ess/nmx/__init__.py
+++ b/src/ess/nmx/__init__.py
@@ -13,11 +13,11 @@ del importlib
 
 from .data import small_mcstas_3_sample
 from .reduction import NMXData, NMXReducedData
-from .types import MaximumProbability
+from .types import MaximumCounts
 
-default_parameters = {MaximumProbability: 10000}
+default_parameters = {MaximumCounts: 10000}
 
-del MaximumProbability
+del MaximumCounts
 
 __all__ = [
     "NMXData",

--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -13,6 +13,7 @@ from ..types import (
     DetectorName,
     EventData,
     FilePath,
+    MaximumCounts,
     MaximumProbability,
     ProtonCharge,
     RawEventData,
@@ -93,24 +94,31 @@ def load_crystal_rotation(
         )
 
 
+def maximum_probability(da: RawEventData) -> MaximumProbability:
+    """Find the maximum probability in the data."""
+    return MaximumProbability(da.data.max())
+
+
 def event_weights_from_probability(
-    da: RawEventData,
-    max_probability: MaximumProbability,
+    da: RawEventData, max_counts: MaximumCounts, max_probability: MaximumProbability
 ) -> EventData:
     """Create event weights by scaling probability data.
 
-    event_weights = max_probability * (probabilities / max(probabilities))
+    event_weights = max_counts * (probabilities / max_probability)
 
     Parameters
     ----------
     da:
         The probabilities of the events
 
+    max_counts:
+        The maximum number of counts after scaling the event counts.
+
     max_probability:
         The maximum probability to scale the weights.
 
     """
-    return sc.scalar(max_probability, unit='counts') * da / da.max()
+    return EventData(sc.scalar(max_counts, unit='counts') * da / max_probability)
 
 
 def proton_charge_from_event_data(da: EventData) -> ProtonCharge:
@@ -185,6 +193,7 @@ providers = (
     detector_name_from_index,
     load_event_data_bank_name,
     load_raw_event_data,
+    maximum_probability,
     event_weights_from_probability,
     proton_charge_from_event_data,
     load_crystal_rotation,

--- a/src/ess/nmx/types.py
+++ b/src/ess/nmx/types.py
@@ -21,6 +21,9 @@ MaximumCounts = NewType("MaximumCounts", int)
 MaximumProbability = NewType("MaximumProbability", sc.Variable)
 """Maximum probability to scale the McStas event counts"""
 
+McStasWeight2CountScaleFactor = NewType("McStasWeight2CountScaleFactor", sc.Variable)
+"""Scale factor to convert McStas weights to counts"""
+
 RawEventData = NewType("RawEventData", sc.DataArray)
 """DataArray containing the event counts read from the McStas file,
 has coordinates 'id' and 't' """

--- a/src/ess/nmx/types.py
+++ b/src/ess/nmx/types.py
@@ -15,8 +15,11 @@ DetectorBankPrefix = NewType("DetectorBankPrefix", str)
 """Prefix identifying the event data array containing
 the events from the selected detector"""
 
-MaximumProbability = NewType("MaximumProbability", int)
+MaximumCounts = NewType("MaximumCounts", int)
 """Maximum number of counts after scaling the event counts"""
+
+MaximumProbability = NewType("MaximumProbability", sc.Variable)
+"""Maximum probability to scale the McStas event counts"""
 
 RawEventData = NewType("RawEventData", sc.DataArray)
 """DataArray containing the event counts read from the McStas file,

--- a/tests/loader_test.py
+++ b/tests/loader_test.py
@@ -15,12 +15,7 @@ from ess.nmx.data import small_mcstas_2_sample, small_mcstas_3_sample
 from ess.nmx.mcstas.load import bank_names_to_detector_names, load_crystal_rotation
 from ess.nmx.mcstas.load import providers as loader_providers
 from ess.nmx.reduction import NMXData
-from ess.nmx.types import (
-    DetectorBankPrefix,
-    DetectorIndex,
-    FilePath,
-    MaximumProbability,
-)
+from ess.nmx.types import DetectorBankPrefix, DetectorIndex, FilePath, MaximumCounts
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from mcstas_description_examples import (
@@ -54,7 +49,7 @@ def check_nmxdata_properties(dg: NMXData, fast_axis, slow_axis) -> None:
     # Check maximum value of weights.
     assert_allclose(
         dg['weights'].max().data,
-        sc.scalar(default_parameters[MaximumProbability], unit='counts', dtype=float),
+        sc.scalar(default_parameters[MaximumCounts], unit='counts', dtype=float),
         atol=sc.scalar(1e-10, unit='counts'),
         rtol=sc.scalar(1e-8),
     )


### PR DESCRIPTION
In order to process data chunk by chunk, `MaximumProbability` has to be also computed chunk by chunk.
Therefore now it's exposed as a parameter not just hard-coded in the provider.

splitting/cleaning up the two other PRs https://github.com/scipp/essnmx/pull/102 and https://github.com/scipp/essnmx/pull/101