### PR TITLE
Retrieving raw data metadata separately

### DIFF
--- a/docs/user-guide/workflow_chunk.ipynb
+++ b/docs/user-guide/workflow_chunk.ipynb
@@ -37,17 +37,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Compute Maximum Probabiliity\n",
+    "## Compute Raw Data Metadata\n",
     "\n",
-    "`McStasWeight2CountScaleFactor` should not be different from chunk to chunk.\n",
+    "`time-of-flight` coordinate and `McStasWeight2CountScaleFactor` should not be different from chunk to chunk.\n",
     "\n",
-    "Therefore we need to compute `McStasWeight2CoutScaleFactor` before we compute `NMXReducedDataGroup`.\n",
+    "Therefore we need to compute `TimeBinStep` and `McStasWeight2CoutScaleFactor` before we compute `NMXReducedData`.\n",
     "\n",
     "It can be done by `ess.reduce.streaming.StreamProcessor`.\n",
     "\n",
-    "In this example, `MaximumProbability` will be renewed every time a chunk is added to the streaming processor.\n",
+    "In this example, `MinimumTimeOfArrival`, `MaximumTimeOfArrival` and `MaximumProbability` will be renewed every time a chunk is added to the streaming processor.\n",
     "\n",
-    "`MaxAccumulator` remembers the previous maximum value and compute new maximum value with the new chunk.\n",
+    "`(Min/Max)Accumulator` remembers the previous minimum/maximum value and compute new minimum/maximum value with the new chunk.\n",
     "\n",
     "``raw_event_data_chunk_generator`` yields a chunk of raw event probability from mcstas h5 file.\n",
     "\n",
@@ -62,16 +62,20 @@
    "source": [
     "from functools import partial\n",
     "from ess.reduce.streaming import StreamProcessor\n",
-    "from ess.nmx.streaming import MaxAccumulator\n",
+    "from ess.nmx.streaming import MaxAccumulator, MinAccumulator\n",
     "\n",
     "# Stream processor building helper\n",
     "scalefactor_stream_processor = partial(\n",
     "    StreamProcessor,\n",
     "    dynamic_keys=(RawEventProbability,),\n",
-    "    target_keys=(McStasWeight2CountScaleFactor,),\n",
-    "    accumulators={MaximumProbability: MaxAccumulator},\n",
+    "    target_keys=(NMXRawDataMetadata,),\n",
+    "    accumulators={\n",
+    "        MaximumProbability: MaxAccumulator,\n",
+    "        MaximumTimeOfArrival: MaxAccumulator,\n",
+    "        MinimumTimeOfArrival: MinAccumulator,\n",
+    "    },\n",
     ")\n",
-    "scalefactor_wf = wf.copy()"
+    "metadata_wf = wf.copy()"
    ]
   },
   {
@@ -80,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scalefactor_wf.visualize(McStasWeight2CountScaleFactor, graph_attr={\"rankdir\": \"TD\"}, compact=True)"
+    "metadata_wf.visualize(NMXRawDataMetadata, graph_attr={\"rankdir\": \"TD\"}, compact=True)"
    ]
   },
   {
@@ -90,7 +94,10 @@
    "outputs": [],
    "source": [
     "from ess.nmx.types import DetectorName\n",
-    "from ess.nmx.mcstas.load import raw_event_data_chunk_generator\n",
+    "from ess.nmx.mcstas.load import (\n",
+    "    raw_event_data_chunk_generator,\n",
+    "    mcstas_weight_to_probability_scalefactor,\n",
+    ")\n",
     "from ess.nmx.streaming import calculate_number_of_chunks\n",
     "from ipywidgets import IntProgress\n",
     "\n",
@@ -99,10 +106,11 @@
     "NUM_DETECTORS = 3\n",
     "\n",
     "# Loop over the detectors\n",
-    "file_path = scalefactor_wf.compute(FilePath)\n",
-    "scale_factors = {}\n",
+    "file_path = metadata_wf.compute(FilePath)\n",
+    "raw_data_metadatas = {}\n",
+    "\n",
     "for detector_i in range(0, NUM_DETECTORS):\n",
-    "    temp_wf = scalefactor_wf.copy()\n",
+    "    temp_wf = metadata_wf.copy()\n",
     "    temp_wf[DetectorIndex] = detector_i\n",
     "    detector_name = temp_wf.compute(DetectorName)\n",
     "    max_chunk_id = calculate_number_of_chunks(\n",
@@ -123,11 +131,18 @@
     "        else:\n",
     "            results = processor.add_chunk({RawEventProbability: da})\n",
     "        cur_detector_progress_bar.value += 1\n",
-    "    scale_factors[detector_i] = results[McStasWeight2CountScaleFactor]\n",
+    "    display(results[NMXRawDataMetadata])\n",
+    "    raw_data_metadatas[detector_i] = results[NMXRawDataMetadata]\n",
     "\n",
-    "# We take the minimum scale factor for the entire dataset\n",
-    "scale_factor = min(scale_factors.values())\n",
-    "scale_factor\n"
+    "# We take the min/maximum values of the scale factor\n",
+    "min_toa = min(dg['min_toa'] for dg in raw_data_metadatas.values())\n",
+    "max_toa = max(dg['max_toa'] for dg in raw_data_metadatas.values())\n",
+    "max_probability = max(dg['max_probability'] for dg in raw_data_metadatas.values())\n",
+    "\n",
+    "toa_bin_edges = sc.linspace(dim='t', start=min_toa, stop=max_toa, num=51)\n",
+    "scale_factor = mcstas_weight_to_probability_scalefactor(\n",
+    "    max_counts=wf.compute(MaximumCounts), max_probability=max_probability\n",
+    ")"
    ]
   },
   {
@@ -150,15 +165,14 @@
     "from ess.nmx.mcstas.xml import McStasInstrument\n",
     "\n",
     "final_wf = wf.copy()\n",
-    "# Add the scale factor to the workflow\n",
+    "# Set the scale factor and time bin edges\n",
     "final_wf[McStasWeight2CountScaleFactor] = scale_factor\n",
+    "final_wf[TimeBinSteps] = toa_bin_edges\n",
     "\n",
-    "# Compute the static information in advance\n",
-    "# static_info = wf.compute([CrystalRotation, McStasInstrument])\n",
-    "static_info = wf.compute([McStasInstrument])\n",
-    "# final_wf[CrystalRotation] = static_info[CrystalRotation]\n",
-    "final_wf[CrystalRotation] = sc.vector([0, 0, 0.,], unit='deg')\n",
-    "final_wf[McStasInstrument] = static_info[McStasInstrument]\n",
+    "# Set the crystal rotation manually for now ...\n",
+    "final_wf[CrystalRotation] = sc.vector([0, 0, 0.0], unit='deg')\n",
+    "# Set static info\n",
+    "final_wf[McStasInstrument] = wf.compute(McStasInstrument)\n",
     "final_wf.visualize(NMXReducedDataGroup, compact=True)"
    ]
   },

--- a/src/ess/nmx/mcstas/__init__.py
+++ b/src/ess/nmx/mcstas/__init__.py
@@ -6,6 +6,8 @@ def McStasWorkflow():
     import sciline as sl
 
     from ess.nmx.reduction import (
+        calculate_maximum_toa,
+        calculate_minimum_toa,
         format_nmx_reduced_data,
         proton_charge_from_event_counts,
         raw_event_probability_to_counts,
@@ -18,6 +20,8 @@ def McStasWorkflow():
     return sl.Pipeline(
         (
             *loader_providers,
+            calculate_maximum_toa,
+            calculate_minimum_toa,
             read_mcstas_geometry_xml,
             proton_charge_from_event_counts,
             reduce_raw_event_probability,

--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -288,16 +288,6 @@ def retrieve_pixel_ids(
     return PixelIds(instrument.pixel_ids(detector_name))
 
 
-def calculate_minimum_toa(da: RawEventProbability) -> MinimumTimeOfArrival:
-    """Calculate the minimum time of arrival from the data."""
-    return MinimumTimeOfArrival(da.coords['t'].min())
-
-
-def calculate_maximum_toa(da: RawEventProbability) -> MaximumTimeOfArrival:
-    """Calculate the maximum time of arrival from the data."""
-    return MaximumTimeOfArrival(da.coords['t'].max())
-
-
 def retrieve_raw_data_metadata(
     min_toa: MinimumTimeOfArrival,
     max_toa: MaximumTimeOfArrival,
@@ -314,8 +304,6 @@ def retrieve_raw_data_metadata(
 
 
 providers = (
-    calculate_minimum_toa,
-    calculate_maximum_toa,
     retrieve_raw_data_metadata,
     read_mcstas_geometry_xml,
     detector_name_from_index,

--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -14,9 +14,12 @@ from ..types import (
     FilePath,
     MaximumCounts,
     MaximumProbability,
+    MaximumTimeOfArrival,
     McStasWeight2CountScaleFactor,
+    MinimumTimeOfArrival,
     NMXDetectorMetadata,
     NMXExperimentMetadata,
+    NMXRawDataMetadata,
     NMXRawEventCountsDataGroup,
     PixelIds,
     RawEventProbability,
@@ -285,7 +288,35 @@ def retrieve_pixel_ids(
     return PixelIds(instrument.pixel_ids(detector_name))
 
 
+def calculate_minimum_toa(da: RawEventProbability) -> MinimumTimeOfArrival:
+    """Calculate the minimum time of arrival from the data."""
+    return MinimumTimeOfArrival(da.coords['t'].min())
+
+
+def calculate_maximum_toa(da: RawEventProbability) -> MaximumTimeOfArrival:
+    """Calculate the maximum time of arrival from the data."""
+    return MaximumTimeOfArrival(da.coords['t'].max())
+
+
+def retrieve_raw_data_metadata(
+    min_toa: MinimumTimeOfArrival,
+    max_toa: MaximumTimeOfArrival,
+    max_probability: MaximumProbability,
+) -> NMXRawDataMetadata:
+    """Retrieve the metadata of the raw data."""
+    return NMXRawDataMetadata(
+        sc.DataGroup(
+            min_toa=min_toa,
+            max_toa=max_toa,
+            max_probability=max_probability,
+        )
+    )
+
+
 providers = (
+    calculate_minimum_toa,
+    calculate_maximum_toa,
+    retrieve_raw_data_metadata,
     read_mcstas_geometry_xml,
     detector_name_from_index,
     load_event_data_bank_name,

--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -15,6 +15,8 @@ from ..types import (
     MaximumCounts,
     MaximumProbability,
     McStasWeight2CountScaleFactor,
+    NMXDetectorMetadata,
+    NMXExperimentMetadata,
     NMXRawEventCountsDataGroup,
     PixelIds,
     RawEventProbability,
@@ -245,22 +247,34 @@ def bank_names_to_detector_names(description: str) -> dict[str, list[str]]:
     return bank_names_to_detector_names
 
 
+def load_experiment_metadata(
+    instrument: McStasInstrument, crystal_rotation: CrystalRotation
+) -> NMXExperimentMetadata:
+    """Load the experiment metadata from the McStas file."""
+    return NMXExperimentMetadata(
+        sc.DataGroup(
+            crystal_rotation=crystal_rotation, **instrument.experiment_metadata()
+        )
+    )
+
+
+def load_detector_metadata(
+    instrument: McStasInstrument, detector_name: DetectorName
+) -> NMXDetectorMetadata:
+    """Load the detector metadata from the McStas file."""
+    return NMXDetectorMetadata(
+        sc.DataGroup(**instrument.detector_metadata(detector_name))
+    )
+
+
 def load_mcstas(
     *,
     da: RawEventProbability,
-    crystal_rotation: CrystalRotation,
-    detector_name: DetectorName,
-    instrument: McStasInstrument,
+    experiment_metadata: NMXExperimentMetadata,
+    detector_metadata: NMXDetectorMetadata,
 ) -> NMXRawEventCountsDataGroup:
-    coords = instrument.to_coords(detector_name)
     return NMXRawEventCountsDataGroup(
-        sc.DataGroup(
-            weights=da,
-            crystal_rotation=crystal_rotation,
-            name=sc.scalar(detector_name),
-            pixel_id=instrument.pixel_ids(detector_name),
-            **coords,
-        )
+        sc.DataGroup(weights=da, **experiment_metadata, **detector_metadata)
     )
 
 
@@ -281,4 +295,6 @@ providers = (
     retrieve_pixel_ids,
     load_crystal_rotation,
     load_mcstas,
+    load_experiment_metadata,
+    load_detector_metadata,
 )

--- a/src/ess/nmx/reduction.py
+++ b/src/ess/nmx/reduction.py
@@ -3,7 +3,9 @@
 import scipp as sc
 
 from .types import (
+    MaximumTimeOfArrival,
     McStasWeight2CountScaleFactor,
+    MinimumTimeOfArrival,
     NMXDetectorMetadata,
     NMXExperimentMetadata,
     NMXReducedCounts,
@@ -14,6 +16,16 @@ from .types import (
     RawEventProbability,
     TimeBinSteps,
 )
+
+
+def calculate_minimum_toa(da: RawEventProbability) -> MinimumTimeOfArrival:
+    """Calculate the minimum time of arrival from the data."""
+    return MinimumTimeOfArrival(da.coords['t'].min())
+
+
+def calculate_maximum_toa(da: RawEventProbability) -> MaximumTimeOfArrival:
+    """Calculate the maximum time of arrival from the data."""
+    return MaximumTimeOfArrival(da.coords['t'].max())
 
 
 def proton_charge_from_event_counts(da: NMXReducedCounts) -> ProtonCharge:

--- a/src/ess/nmx/reduction.py
+++ b/src/ess/nmx/reduction.py
@@ -2,11 +2,10 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 import scipp as sc
 
-from .mcstas.xml import McStasInstrument
 from .types import (
-    CrystalRotation,
-    DetectorName,
     McStasWeight2CountScaleFactor,
+    NMXDetectorMetadata,
+    NMXExperimentMetadata,
     NMXReducedCounts,
     NMXReducedDataGroup,
     NMXReducedProbability,
@@ -53,20 +52,18 @@ def raw_event_probability_to_counts(
 
 def format_nmx_reduced_data(
     da: NMXReducedCounts,
-    detector_name: DetectorName,
-    instrument: McStasInstrument,
     proton_charge: ProtonCharge,
-    crystal_rotation: CrystalRotation,
+    experiment_metadata: NMXExperimentMetadata,
+    detector_metadata: NMXDetectorMetadata,
 ) -> NMXReducedDataGroup:
     """Bin time of arrival data into ``time_bin_step`` bins."""
-    new_coords = instrument.to_coords(detector_name)
 
     return NMXReducedDataGroup(
         sc.DataGroup(
             counts=da,
             proton_charge=proton_charge,
-            crystal_rotation=crystal_rotation,
-            **new_coords,
+            **experiment_metadata,
+            **detector_metadata,
         )
     )
 

--- a/src/ess/nmx/types.py
+++ b/src/ess/nmx/types.py
@@ -24,13 +24,18 @@ MaximumProbability = NewType("MaximumProbability", sc.Variable)
 McStasWeight2CountScaleFactor = NewType("McStasWeight2CountScaleFactor", sc.Variable)
 """Scale factor to convert McStas weights to counts"""
 
+NMXExperimentMetadata = NewType("NMXExperimentMetadata", sc.DataGroup)
+"""Metadata of the experiment"""
+
+NMXDetectorMetadata = NewType("NMXDetectorMetadata", sc.DataGroup)
+"""Metadata of the detector"""
 
 RawEventProbability = NewType("RawEventProbability", sc.DataArray)
 """DataArray containing the event probabilities read from the McStas file,
 has coordinates 'id' and 't' """
 
 NMXRawEventCountsDataGroup = NewType("NMXRawEventCountsDataGroup", sc.DataGroup)
-"""DataGroup containing the RawEventData and other metadata"""
+"""DataGroup containing the RawEventData, experiment metadata and detector metadata"""
 
 ProtonCharge = NewType("ProtonCharge", sc.Variable)
 """The proton charge signal"""
@@ -54,4 +59,4 @@ NMXReducedCounts = NewType("NMXReducedCounts", sc.DataArray)
 """Histogram of time-of-arrival and pixel-id."""
 
 NMXReducedDataGroup = NewType("NMXReducedDataGroup", sc.DataGroup)
-"""Histogram of time-of-arrival and pixel-id, with additional metadata."""
+"""Datagroup containing Histogram(id, t), experiment metadata and detector metadata"""

--- a/src/ess/nmx/types.py
+++ b/src/ess/nmx/types.py
@@ -60,3 +60,12 @@ NMXReducedCounts = NewType("NMXReducedCounts", sc.DataArray)
 
 NMXReducedDataGroup = NewType("NMXReducedDataGroup", sc.DataGroup)
 """Datagroup containing Histogram(id, t), experiment metadata and detector metadata"""
+
+MinimumTimeOfArrival = NewType("MinimumTimeOfArrival", sc.Variable)
+"""Minimum time of arrival of the raw data"""
+
+MaximumTimeOfArrival = NewType("MaximumTimeOfArrival", sc.Variable)
+"""Maximum time of arrival of the raw data"""
+
+NMXRawDataMetadata = NewType("NMXRawDataMetadata", sc.DataGroup)
+"""Metadata of the raw data, i.e. maximum weight and min/max time of arrival"""

--- a/tests/loader_test.py
+++ b/tests/loader_test.py
@@ -47,10 +47,8 @@ def check_nmxdata_properties(
     dg: NMXRawEventCountsDataGroup, fast_axis, slow_axis
 ) -> None:
     assert isinstance(dg, sc.DataGroup)
-    assert_allclose(
-        sc.squeeze(dg['fast_axis'], 'panel'), fast_axis, atol=sc.scalar(0.005)
-    )
-    assert_identical(sc.squeeze(dg['slow_axis'], 'panel'), slow_axis)
+    assert_allclose(dg['fast_axis'], fast_axis, atol=sc.scalar(0.005))
+    assert_identical(dg['slow_axis'], slow_axis)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We would like to retrieve some statistics, i.e. min/max of time of arrival from the data without reducing the data.

So I separated this step out of the loader.