### PR TITLE
remove all zero lines, not just the first one

### DIFF
--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -52,8 +52,7 @@ def _exclude_zero_events(data: sc.Variable) -> sc.Variable:
     McStas can add extra event lines containing 0,0,0,0,0,0
     These lines should not be included so we skip it.
     """
-    nonzeros = data.values[(data.values != 0).all(axis=1)]
-    data = sc.array(dims=['event', 'dim_1'], values=nonzeros, unit=None)
+    data  = data[(data!=sc.scalar(0., unit=data.unit)).any(dim="dim_1")]
     return data
 
 

--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -52,8 +52,8 @@ def _exclude_zero_events(data: sc.Variable) -> sc.Variable:
     McStas can add extra event lines containing 0,0,0,0,0,0
     These lines should not be included so we skip it.
     """
-    nonzeros = data.values[(data.values!=0).all(axis=1)]
-    data = sc.array(dims=['event', 'dim_1'], values=nonzeros, unit=None )
+    nonzeros = data.values[(data.values != 0).all(axis=1)]
+    data = sc.array(dims=['event', 'dim_1'], values=nonzeros, unit=None)
     return data
 
 

--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -52,7 +52,7 @@ def _exclude_zero_events(data: sc.Variable) -> sc.Variable:
     McStas can add extra event lines containing 0,0,0,0,0,0
     These lines should not be included so we skip it.
     """
-    data  = data[(data!=sc.scalar(0., unit=data.unit)).any(dim="dim_1")]
+    data = data[(data != sc.scalar(0.0, unit=data.unit)).any(dim="dim_1")]
     return data
 
 

--- a/src/ess/nmx/mcstas/load.py
+++ b/src/ess/nmx/mcstas/load.py
@@ -49,13 +49,11 @@ def load_event_data_bank_name(
 def _exclude_zero_events(data: sc.Variable) -> sc.Variable:
     """Exclude events with zero counts from the data.
 
-    McStas can add an extra event line containing 0,0,0,0,0,0
-    This line should not be included so we skip it.
+    McStas can add extra event lines containing 0,0,0,0,0,0
+    These lines should not be included so we skip it.
     """
-    if (data.values[0] == 0).all():
-        data = data["event", 1:]
-    else:
-        data = data
+    nonzeros = data.values[(data.values!=0).all(axis=1)]
+    data = sc.array(dims=['event', 'dim_1'], values=nonzeros, unit=None )
     return data
 
 


### PR DESCRIPTION
Changed filter function to exclude zero lines from McStas, which happen far more than only once at the beginning of the datasets, as was initially assumed. Note the performance takes a big hit due to this filtering function, but it is needed for now, until McStas is fixed. (I am not too concerned about performance.)