### PR TITLE
Export first pixel position for DIALS

### DIFF
--- a/src/ess/nmx/types.py
+++ b/src/ess/nmx/types.py
@@ -104,6 +104,11 @@ class NMXDetectorMetadata:
     fast_axis: sc.Variable
     slow_axis: sc.Variable
     distance: sc.Variable
+    first_pixel_position: sc.Variable
+    """First pixel position with respect to the sample.
+
+    Additional field for DIALS. It should be a 3D vector.
+    """
     # TODO: Remove hardcoded values
     polar_angle: sc.Variable = field(default_factory=lambda: sc.scalar(0, unit='deg'))
     azimuthal_angle: sc.Variable = field(
@@ -117,5 +122,6 @@ class NMXDetectorMetadata:
         snx.create_field(group, 'fast_axis', self.fast_axis)
         snx.create_field(group, 'slow_axis', self.slow_axis)
         snx.create_field(group, 'distance', self.distance)
+        snx.create_field(group, 'first_pixel_position', self.first_pixel_position)
         snx.create_field(group, 'polar_angle', self.polar_angle)
         snx.create_field(group, 'azimuthal_angle', self.azimuthal_angle)

--- a/src/ess/nmx/types.py
+++ b/src/ess/nmx/types.py
@@ -118,10 +118,10 @@ class NMXDetectorMetadata:
     def __write_to_nexus_group__(self, group: h5py.Group):
         snx.create_field(group, 'x_pixel_size', self.x_pixel_size)
         snx.create_field(group, 'y_pixel_size', self.y_pixel_size)
-        snx.create_field(group, 'origin', self.origin_position)
+        origin = snx.create_field(group, 'origin', self.origin_position)
+        origin.attrs['first_pixel_position'] = self.first_pixel_position.values
         snx.create_field(group, 'fast_axis', self.fast_axis)
         snx.create_field(group, 'slow_axis', self.slow_axis)
         snx.create_field(group, 'distance', self.distance)
-        snx.create_field(group, 'first_pixel_position', self.first_pixel_position)
         snx.create_field(group, 'polar_angle', self.polar_angle)
         snx.create_field(group, 'azimuthal_angle', self.azimuthal_angle)


### PR DESCRIPTION
It should also fixes (partially) scipp/ess#190 .

In the NXLauetof format everything is based on the center position of the detector, so we the center position as `origin_position` but the DIALS expect the origin position to be the top-left (first pixel position).
It's not simply the top left in the space since NMX detector panels can translate/rotate along all three axis, x, y, z.
So the workflow finds the lowest pixel ID in each panel and find the position of that pixel.
