### PR TITLE
'definitions' to 'definition'

### DIFF
--- a/src/ess/nmx/nexus.py
+++ b/src/ess/nmx/nexus.py
@@ -176,7 +176,7 @@ def export_static_metadata_as_nxlauetof(
     with snx.File(output_file, "w") as f:
         f._group.attrs["NX_class"] = "NXlauetof"
         nx_entry = f.create_class(name='entry', class_name='NXlauetof')
-        nx_entry.create_field('definitions', value='NXlauetof')
+        nx_entry.create_field('definition', value='NXlauetof')
         nx_entry['sample'] = sample_metadata
 
         nx_instrument = _set_default_instrument(nx_entry)


### PR DESCRIPTION
I'm pretty sure this is a typo in `nexus.py`... `/entry/definitions` should be `/entry/definition`